### PR TITLE
Fix rx-monitoring

### DIFF
--- a/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/mixer/templates/deployment.yaml
@@ -427,7 +427,7 @@ spec:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9093,42422"
+        prometheus.io/port: "42422"
 {{- with $.Values.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}


### PR DESCRIPTION
With rx prometheus, a pod with two ports configured in "prometheus.io/port" will be ignored. Currently mixer is configured with two ports:
* 9093: mixer itself
* 42422: metrics from other pods in mesh
which results in no metrics at all. To have at least the metrics from our pods in the mesh, I removed the 9093 port and only configure the 42422 port.