### PR TITLE
enable pilot and galley ports for external prometheus scraping

### DIFF
--- a/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml
@@ -30,7 +30,8 @@ spec:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9093"
+        prometheus.io/port: "15014"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: istio-galley-service-account
 {{- if .Values.global.priorityClassName }}

--- a/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
+++ b/install/kubernetes/helm/istio/charts/pilot/templates/deployment.yaml
@@ -39,7 +39,8 @@ spec:
         sidecar.istio.io/inject: "false"
         scheduler.alpha.kubernetes.io/critical-pod: ""
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9093"
+        prometheus.io/port: "15014"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: istio-pilot-service-account
 {{- if .Values.global.priorityClassName }}


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

In an external prometheus galley and pilot targets are marked as "Down". The metrics of both can be found on port 15014 and not on 9093 (see git push --set-upstream origin fix_galley_pilot_port_external_prometheus)